### PR TITLE
Improve REPL integration

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <!-- this version is also used to download the lsp shaded server jar -->
-    <ide.lsp.version>0.0.9</ide.lsp.version>
+    <ide.lsp.version>0.0.10</ide.lsp.version>
   </properties>
 
   <dependencies>
@@ -32,43 +32,43 @@
     <dependency>
       <groupId>org.finos.legend.engine</groupId>
       <artifactId>legend-engine-extensions-collection-execution</artifactId>
-      <version>4.39.1</version>
+      <version>4.42.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.finos.legend.engine</groupId>
       <artifactId>legend-engine-extensions-collection-generation</artifactId>
-      <version>4.39.1</version>
+      <version>4.42.0</version>
     </dependency>
 
     <dependency>
-      <groupId>org.finos.legend.engine</groupId>
-      <artifactId>legend-engine-configuration</artifactId>
-      <version>4.39.1</version>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-configuration-plan-generation-serialization</artifactId>
+        <version>4.42.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.finos.legend.engine</groupId>
       <artifactId>legend-engine-test-runner-shared</artifactId>
-      <version>4.39.1</version>
+      <version>4.42.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.finos.legend.engine</groupId>
       <artifactId>legend-engine-test-runner-mapping</artifactId>
-      <version>4.39.1</version>
+      <version>4.42.0</version>
     </dependency>    
 
     <dependency>
       <groupId>org.finos.legend.engine</groupId>
       <artifactId>legend-engine-test-runner-service</artifactId>
-      <version>4.39.1</version>
+      <version>4.42.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.finos.legend.sdlc</groupId>
       <artifactId>legend-sdlc-test-utils</artifactId>
-      <version>0.156.1</version>
+      <version>0.158.0</version>
       <exclusions>
         <exclusion>
             <groupId>org.finos.legend.pure</groupId>
@@ -84,9 +84,39 @@
     <dependency>
       <groupId>org.finos.legend.engine</groupId>
       <artifactId>legend-engine-repl-client</artifactId>
-      <version>4.39.1</version>
+      <version>4.42.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.finos.legend.engine</groupId>
+      <artifactId>legend-engine-repl-relational</artifactId>
+      <version>4.42.0</version>
+    </dependency>    
+
   </dependencies>
+
+  <!-- todo update to use engine dependency - https://github.com/finos/legend-engine/pull/2721 -->
+  <profiles>
+      <profile>
+          <id>platform-windows</id>
+          <activation>
+              <os>
+                  <family>windows</family>
+              </os>
+          </activation>
+          <dependencies>
+              <dependency>
+                  <groupId>org.jline</groupId>
+                  <artifactId>jline-terminal-jansi</artifactId>
+                  <version>3.25.0</version>
+              </dependency>
+              <dependency>
+                  <groupId>org.fusesource.jansi</groupId>
+                  <artifactId>jansi</artifactId>
+                  <version>2.4.1</version>
+              </dependency>
+          </dependencies>
+      </profile>
+  </profiles>
 
 </project>

--- a/src/LegendLanguageClient.ts
+++ b/src/LegendLanguageClient.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import type { CancellationToken } from 'vscode';
 import type { FunctionTDSRequest } from './model/FunctionTDSRequest';
 import type { LegendExecutionResult } from './results/LegendExecutionResult';
-import { TDS_JSON_REQUEST_ID } from './utils/Const';
+import { REPL_CLASSPATH_REQUEST_ID, TDS_JSON_REQUEST_ID } from './utils/Const';
 import type { PlainObject } from './utils/SerializationUtils';
 import { LanguageClient } from 'vscode-languageclient/node';
 
@@ -25,5 +26,9 @@ export class LegendLanguageClient extends LanguageClient {
     request: FunctionTDSRequest,
   ): Promise<PlainObject<LegendExecutionResult>> {
     return this.sendRequest(TDS_JSON_REQUEST_ID, request);
+  }
+
+  async replClasspath(token?: CancellationToken): Promise<string> {
+    return this.sendRequest(REPL_CLASSPATH_REQUEST_ID, token);
   }
 }

--- a/src/utils/Const.ts
+++ b/src/utils/Const.ts
@@ -40,6 +40,7 @@ export const EXEC_FUNCTION_WITH_PARAMETERS_ID =
 export const EXEC_FUNCTION_ID = 'legend.pure.executeFunction';
 export const SEND_TDS_REQUEST_ID = 'sendTDSRequest';
 export const TDS_JSON_REQUEST_ID = 'legend/TDSRequest';
+export const REPL_CLASSPATH_REQUEST_ID = 'legend/replClasspath';
 export const GET_TDS_REQUEST_RESULTS_ID = 'getTDSRequestResultsId';
 
 // Context variables


### PR DESCRIPTION
This PR improve the REPL integration by reducing the number of parameters the REPL main class receives and delegates the classpath construction to the language server. This avoids duplicating the complexities the language server already handle, and improve the REPL performance too.

![terminal](https://github.com/finos/legend-engine-ide-client-vscode/assets/24432403/45c1181b-b817-4e4a-a58f-a19be58baee2)
