### PR TITLE
Support restarting language server on scenarios that can impact its startup behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,12 @@
         "command": "legend.log",
         "title": "Show Language Server log",
         "category": "Legend"
-      }
+      },
+      {
+        "command": "legend.reload",
+        "title": "Reload Extension",
+        "category": "Legend"
+      }      
     ],
     "configuration": {
       "type": "object",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,10 +133,15 @@ export function createClient(context: ExtensionContext): LanguageClient {
   workspace.onDidSaveTextDocument((e) => {
     if (e.fileName.endsWith('pom.xml')) {
       window
-        .showInformationMessage('Reload Legend Extension?', 
-        { modal: true, detail: `You just change POM file that can affect your project dependencies.  Should reload to pick changes?`},
-        'Reload')
-        .then(answer => {
+        .showInformationMessage(
+          'Reload Legend Extension?',
+          {
+            modal: true,
+            detail: `You just change POM file that can affect your project dependencies.  Should reload to pick changes?`,
+          },
+          'Reload',
+        )
+        .then((answer) => {
           if (answer === 'Reload') {
             return client.restart();
           }
@@ -146,20 +151,27 @@ export function createClient(context: ExtensionContext): LanguageClient {
 
   // if settings change, ask user if we should reload extension
   workspace.onDidChangeConfiguration((e) => {
-    if (e.affectsConfiguration('legend.sdlc.server.url') 
-      || e.affectsConfiguration('legend.extensions.other.dependencies')
-      || e.affectsConfiguration('legend.extensions.dependencies.pom')) {
-        window
-        .showInformationMessage('Reload Legend Extension?', 
-        { modal: true, detail: `You just change a configuration setting that can affect your project dependencies.  Should reload to pick changes?`},
-        'Reload')
-        .then(answer => {
+    if (
+      e.affectsConfiguration('legend.sdlc.server.url') ||
+      e.affectsConfiguration('legend.extensions.other.dependencies') ||
+      e.affectsConfiguration('legend.extensions.dependencies.pom')
+    ) {
+      window
+        .showInformationMessage(
+          'Reload Legend Extension?',
+          {
+            modal: true,
+            detail: `You just change a configuration setting that can affect your project dependencies.  Should reload to pick changes?`,
+          },
+          'Reload',
+        )
+        .then((answer) => {
           if (answer === 'Reload') {
             return client.restart();
           }
         });
     }
-  })
+  });
 
   return client;
 }
@@ -368,7 +380,7 @@ export function createStatusBarItem(context: ExtensionContext): void {
         },
         {
           label: '$(refresh) Reload Legend Extension',
-          command: 'legend.reload'
+          command: 'legend.reload',
         },
         {
           label: '$(settings-gear) Open Legend Settings',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,6 +128,39 @@ export function createClient(context: ExtensionContext): LanguageClient {
   );
   // Initialize client
   client.start();
+
+  // if pom changes, ask user if we should reload extension
+  workspace.onDidSaveTextDocument((e) => {
+    if (e.fileName.endsWith('pom.xml')) {
+      window
+        .showInformationMessage('Reload Legend Extension?', 
+        { modal: true, detail: `You just change POM file that can affect your project dependencies.  Should reload to pick changes?`},
+        'Reload')
+        .then(answer => {
+          if (answer === 'Reload') {
+            return client.restart();
+          }
+        });
+    }
+  });
+
+  // if settings change, ask user if we should reload extension
+  workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration('legend.sdlc.server.url') 
+      || e.affectsConfiguration('legend.extensions.other.dependencies')
+      || e.affectsConfiguration('legend.extensions.dependencies.pom')) {
+        window
+        .showInformationMessage('Reload Legend Extension?', 
+        { modal: true, detail: `You just change a configuration setting that can affect your project dependencies.  Should reload to pick changes?`},
+        'Reload')
+        .then(answer => {
+          if (answer === 'Reload') {
+            return client.restart();
+          }
+        });
+    }
+  })
+
   return client;
 }
 
@@ -163,6 +196,11 @@ export function registerCommands(context: ExtensionContext): void {
     });
   });
   context.subscriptions.push(openLog);
+
+  const reloadServer = commands.registerCommand('legend.reload', () => {
+    client.restart();
+  });
+  context.subscriptions.push(reloadServer);
 
   const functiontds = commands.registerCommand(
     SEND_TDS_REQUEST_ID,
@@ -327,6 +365,10 @@ export function createStatusBarItem(context: ExtensionContext): void {
         {
           label: '$(go-to-file) Show Language Server log',
           command: 'legend.log',
+        },
+        {
+          label: '$(refresh) Reload Legend Extension',
+          command: 'legend.reload'
         },
         {
           label: '$(settings-gear) Open Legend Settings',


### PR DESCRIPTION
This PR introduce a restart modal asking user if they want to apply their recent changes.  This includes changes to POM.xml, or extension setting: `legend.sdlc.server.url`, `legend.extensions.other.dependencies`, `legend.extensions.dependencies.pom`.

This also introduce a restart command user can execute as their own request. 