### PR TITLE
Update legend.svg to display better on dark themes

### DIFF
--- a/icons/legend.svg
+++ b/icons/legend.svg
@@ -1,5 +1,10 @@
-<svg role="img" viewBox="0 0 215 215" xmlns="http://www.w3.org/2000/svg">
-  
- <path d="M205,170.7L152.7,139.1C150,137.4 147.7,138.7 147.7,141.9L147.7,157.9L55.8,157.9L55.8,59.4L67.2,59.4C70.4,59.4 71.7,57.2 70,54.4L38.4,2.1C36.7,-0.6 34.1,-0.6 32.4,2.1L0.7,54.4C-1,57.1 0.3,59.4 3.5,59.4L15.6,59.4L15.6,185.5C15.6,188.5 18,190.9 21,190.9L147.7,190.9L147.7,205.7C147.7,208.9 149.9,210.1 152.7,208.5L205,176.9C207.7,175.1 207.7,172.4 205,170.7Z" />
-
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1080" height="1080" viewBox="0 0 1080 1080" xml:space="preserve">
+  <g transform="matrix(Infinity NaN NaN Infinity 0 0)" id="c5a27e70-13cf-4a54-83b2-d082e9713b02"  >
+  </g>
+  <g transform="matrix(1 0 0 1 540 540)" id="cbc3c39f-face-4a88-81b2-9be0b4f54b1e"  >
+    <rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1; visibility: hidden;" vector-effect="non-scaling-stroke"  x="-540" y="-540" rx="0" ry="0" width="1080" height="1080" />
+  </g>
+  <g transform="matrix(5.02 0 0 5.02 540 540)"  >
+    <path style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(135,135,135); fill-rule: nonzero; opacity: 1;"  transform=" translate(-103.49, -104.64)" d="M 205 170.7 L 152.7 139.1 C 150 137.4 147.7 138.7 147.7 141.9 L 147.7 157.9 L 55.8 157.9 L 55.8 59.4 L 67.2 59.4 C 70.4 59.4 71.7 57.2 70 54.4 L 38.4 2.1 C 36.7 -0.6 34.1 -0.6 32.4 2.1 L 0.7 54.4 C -1 57.1 0.3 59.4 3.5 59.4 L 15.6 59.4 L 15.6 185.5 C 15.6 188.5 18 190.9 21 190.9 L 147.7 190.9 L 147.7 205.7 C 147.7 208.9 149.9 210.1 152.7 208.5 L 205 176.9 C 207.7 175.1 207.7 172.4 205 170.7 Z" stroke-linecap="round" />
+  </g>
 </svg>

--- a/icons/legend.svg
+++ b/icons/legend.svg
@@ -1,10 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1080" height="1080" viewBox="0 0 1080 1080" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="150" height="150" viewBox="0 0 150 150" xml:space="preserve">
+  <rect x="0" y="0" width="100%" height="100%" fill="transparent"></rect>
   <g transform="matrix(Infinity NaN NaN Infinity 0 0)" id="c5a27e70-13cf-4a54-83b2-d082e9713b02"  >
   </g>
-  <g transform="matrix(1 0 0 1 540 540)" id="cbc3c39f-face-4a88-81b2-9be0b4f54b1e"  >
-    <rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1; visibility: hidden;" vector-effect="non-scaling-stroke"  x="-540" y="-540" rx="0" ry="0" width="1080" height="1080" />
+  <g transform="matrix(1 0 0 1 75 75)" id="cbc3c39f-face-4a88-81b2-9be0b4f54b1e"  >
+    <rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1; visibility: hidden;" vector-effect="non-scaling-stroke"  x="-75" y="-75" rx="0" ry="0" width="150" height="150" />
   </g>
-  <g transform="matrix(5.02 0 0 5.02 540 540)"  >
+  <g transform="matrix(0.7 0 0 0.7 75 75)"  >
     <path style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(135,135,135); fill-rule: nonzero; opacity: 1;"  transform=" translate(-103.49, -104.64)" d="M 205 170.7 L 152.7 139.1 C 150 137.4 147.7 138.7 147.7 141.9 L 147.7 157.9 L 55.8 157.9 L 55.8 59.4 L 67.2 59.4 C 70.4 59.4 71.7 57.2 70 54.4 L 38.4 2.1 C 36.7 -0.6 34.1 -0.6 32.4 2.1 L 0.7 54.4 C -1 57.1 0.3 59.4 3.5 59.4 L 15.6 59.4 L 15.6 185.5 C 15.6 188.5 18 190.9 21 190.9 L 147.7 190.9 L 147.7 205.7 C 147.7 208.9 149.9 210.1 152.7 208.5 L 205 176.9 C 207.7 175.1 207.7 172.4 205 170.7 Z" stroke-linecap="round" />
   </g>
 </svg>


### PR DESCRIPTION
Dark theme:

<img width="647" alt="image" src="https://github.com/finos/legend-engine-ide-client-vscode/assets/24432403/b12d2618-714f-453a-9691-e13652c40623">

Light theme:

<img width="571" alt="image" src="https://github.com/finos/legend-engine-ide-client-vscode/assets/24432403/c8cbdfea-4443-45d4-9afb-713d82f9d8d9">
