### PR TITLE
repl: make sure to wait for classpath computation before start

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <!-- this version is also used to download the lsp shaded server jar -->
-    <ide.lsp.version>0.6.0</ide.lsp.version>
+    <ide.lsp.version>0.6.1</ide.lsp.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
- [x] wait for classpath computation and block opening terminal till then - relies on https://github.com/finos/legend-engine-ide-lsp/pull/229
- [x] show progress (wait) notification while initializing REPL

https://github.com/user-attachments/assets/9ca38aa4-cde7-4cf8-b5e6-b3d62cac2b60

