### PR TITLE
Create separate config fields for diagram editor file and query builder file

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,10 +203,15 @@
           },
           "description": "Specifies extra VM arguments used to launch the Legend Language REPL"
         },
-        "legend.studio.forms.file": {
+        "legend.studio.forms.diagramEditorFile": {
           "type": "string",
           "default": "",
-          "description": "Specifies file to be used for legend studio web forms"
+          "description": "Specifies file to be used for legend studio diagram editor"
+        },
+        "legend.studio.forms.serviceQueryBuilderFile": {
+          "type": "string",
+          "default": "",
+          "description": "Specifies file to be used for legend studio service query builder"
         },
         "legend.planExecutor.configuration": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,7 +248,7 @@ const showDiagramWebView = async (
       context,
       diagramId,
       entities,
-      workspace.getConfiguration('legend').get('studio.forms.file', ''),
+      workspace.getConfiguration('legend').get('studio.forms.diagramEditorFile', ''),
       client,
     );
   }
@@ -364,7 +364,7 @@ export function registerCommands(context: ExtensionContext): void {
           context,
           serviceId,
           workspace.getConfiguration('legend').get('engine.server.url', ''),
-          workspace.getConfiguration('legend').get('studio.forms.file', ''),
+          workspace.getConfiguration('legend').get('studio.forms.serviceQueryBuilderFile', ''),
           client,
         );
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,7 +248,9 @@ const showDiagramWebView = async (
       context,
       diagramId,
       entities,
-      workspace.getConfiguration('legend').get('studio.forms.diagramEditorFile', ''),
+      workspace
+        .getConfiguration('legend')
+        .get('studio.forms.diagramEditorFile', ''),
       client,
     );
   }
@@ -364,7 +366,9 @@ export function registerCommands(context: ExtensionContext): void {
           context,
           serviceId,
           workspace.getConfiguration('legend').get('engine.server.url', ''),
-          workspace.getConfiguration('legend').get('studio.forms.serviceQueryBuilderFile', ''),
+          workspace
+            .getConfiguration('legend')
+            .get('studio.forms.serviceQueryBuilderFile', ''),
           client,
         );
       }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

Improvement

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

Rename `legend.studio.forms.file` to `legend.studio.forms.diagramEditorFile` for diagram editor file, and add new config field `legend.studio.forms.serviceQueryBuilderFile` for the service query editor file. This is done so we can support query builder file, which is separate from diagram editor.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->

Yes