### PR TITLE
Reduce number of entities fetched to build graph

### DIFF
--- a/src/LegendCodelensProvider.ts
+++ b/src/LegendCodelensProvider.ts
@@ -61,9 +61,10 @@ export class LegendCodelensProvider implements CodeLensProvider {
   ): Promise<CodeLens[]> {
     this.codeLenses = [];
     const entities = await this.client.entities(
-      new LegendEntitiesRequest([
-        TextDocumentIdentifier.create(document.uri.toString()),
-      ]),
+      new LegendEntitiesRequest(
+        [TextDocumentIdentifier.create(document.uri.toString())],
+        [],
+      ),
       _token,
     );
     entities.forEach((entity) => {

--- a/src/LegendLanguageClient.ts
+++ b/src/LegendLanguageClient.ts
@@ -66,9 +66,11 @@ import { type TextLocation } from './model/TextLocation';
 
 export class LegendEntitiesRequest {
   private textDocuments!: TextDocumentIdentifier[];
+  private entityPaths!: string[];
 
-  constructor(textDocuments: TextDocumentIdentifier[]) {
+  constructor(textDocuments: TextDocumentIdentifier[], entityPaths: string[]) {
     this.textDocuments = textDocuments;
+    this.entityPaths = entityPaths;
   }
 }
 

--- a/src/components/query/QueryBuilderStateUtils.ts
+++ b/src/components/query/QueryBuilderStateUtils.ts
@@ -45,14 +45,11 @@ import {
   CLASSIFIER_PATH,
   GET_PROJECT_ENTITIES_RESPONSE,
   GET_PROJECT_ENTITIES,
-  GET_ENTITY_TEXT_LOCATION,
-  GET_ENTITY_TEXT_LOCATION_RESPONSE,
 } from '../../utils/Const';
 import { postAndWaitForMessage } from '../../utils/VsCodeUtils';
 import { type LegendVSCodePluginManager } from '../../application/LegendVSCodePluginManager';
 import { type LegendExecutionResult } from '../../results/LegendExecutionResult';
 import { V1_LSPMappingModelCoverageAnalysisResult } from '../../model/engine/MappingModelCoverageAnalysisResult';
-import { type TextLocation } from '../../model/TextLocation';
 
 const isServiceWithNonPointerRuntime = (
   entity: Entity,
@@ -192,24 +189,18 @@ export const getMinimalEntities = async (
   entities: Entity[];
   dummyElements: V1_PackageableElement[];
 }> => {
-  const currentEntityTextLocation = await postAndWaitForMessage<TextLocation>(
-    {
-      command: GET_ENTITY_TEXT_LOCATION,
-      msg: { entityId },
-    },
-    GET_ENTITY_TEXT_LOCATION_RESPONSE,
-  );
-  const entitiesInTextLocation = await postAndWaitForMessage<Entity[]>(
-    {
-      command: GET_PROJECT_ENTITIES,
-      msg: {
-        entityTextLocations: [currentEntityTextLocation],
-      },
-    },
-    GET_PROJECT_ENTITIES_RESPONSE,
-  );
   const currentEntity = guaranteeNonNullable(
-    entitiesInTextLocation.find((entity) => entity.path === entityId),
+    (
+      await postAndWaitForMessage<Entity[]>(
+        {
+          command: GET_PROJECT_ENTITIES,
+          msg: {
+            entityPaths: [entityId],
+          },
+        },
+        GET_PROJECT_ENTITIES_RESPONSE,
+      )
+    )[0],
     `Can't find entity with ID ${entityId}`,
   );
 

--- a/src/components/query/QueryBuilderStateUtils.ts
+++ b/src/components/query/QueryBuilderStateUtils.ts
@@ -52,7 +52,7 @@ import { postAndWaitForMessage } from '../../utils/VsCodeUtils';
 import { type LegendVSCodePluginManager } from '../../application/LegendVSCodePluginManager';
 import { type LegendExecutionResult } from '../../results/LegendExecutionResult';
 import { V1_LSPMappingModelCoverageAnalysisResult } from '../../model/engine/MappingModelCoverageAnalysisResult';
-import { TextLocation } from '../../model/TextLocation';
+import { type TextLocation } from '../../model/TextLocation';
 
 const isServiceWithNonPointerRuntime = (
   entity: Entity,

--- a/src/components/query/QueryBuilderStateUtils.ts
+++ b/src/components/query/QueryBuilderStateUtils.ts
@@ -199,18 +199,17 @@ export const getMinimalEntities = async (
     },
     GET_ENTITY_TEXT_LOCATION_RESPONSE,
   );
+  const entitiesInTextLocation = await postAndWaitForMessage<Entity[]>(
+    {
+      command: GET_PROJECT_ENTITIES,
+      msg: {
+        entityTextLocations: [currentEntityTextLocation],
+      },
+    },
+    GET_PROJECT_ENTITIES_RESPONSE,
+  );
   const currentEntity = guaranteeNonNullable(
-    (
-      await postAndWaitForMessage<Entity[]>(
-        {
-          command: GET_PROJECT_ENTITIES,
-          msg: {
-            entityTextLocations: [currentEntityTextLocation],
-          },
-        },
-        GET_PROJECT_ENTITIES_RESPONSE,
-      )
-    )[0],
+    entitiesInTextLocation.find((entity) => entity.path === entityId),
     `Can't find entity with ID ${entityId}`,
   );
 

--- a/src/conceptTree.ts
+++ b/src/conceptTree.ts
@@ -204,7 +204,7 @@ export class LegendConceptTreeProvider
   async refresh(doc?: TextDocument): Promise<void> {
     if (!doc || this.root.childrenMap.size === 0) {
       const entities = await this.client.entities(
-        new LegendEntitiesRequest([]),
+        new LegendEntitiesRequest([], []),
       );
       this.root.childrenMap.clear();
       entities
@@ -216,7 +216,7 @@ export class LegendConceptTreeProvider
     } else {
       const docUri = doc.uri.toString();
       const entities = await this.client.entities(
-        new LegendEntitiesRequest([TextDocumentIdentifier.create(docUri)]),
+        new LegendEntitiesRequest([TextDocumentIdentifier.create(docUri)], []),
       );
       this.removeEntitiesFrom(new Map(), this.root, docUri);
       entities

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,9 +183,10 @@ export function createClient(context: ExtensionContext): LanguageClient {
   // if query changes, we should reload any query builders that are open.
   workspace.onDidSaveTextDocument(async (e: TextDocument) => {
     const updatedEntities = await client.entities(
-      new LegendEntitiesRequest([
-        TextDocumentIdentifier.create(e.uri.toString()),
-      ]),
+      new LegendEntitiesRequest(
+        [TextDocumentIdentifier.create(e.uri.toString())],
+        [],
+      ),
     );
     updatedEntities.forEach((updatedEntity) => {
       const normalizedEntityId =
@@ -282,7 +283,7 @@ const showDiagramWebView = async (
     });
     openedWebViews[diagramId] = diagramRendererWebView;
 
-    const entities = await client.entities(new LegendEntitiesRequest([]));
+    const entities = await client.entities(new LegendEntitiesRequest([], []));
     renderDiagramRendererWebView(
       diagramRendererWebView,
       context,
@@ -305,9 +306,12 @@ const showQueryBuilderWebView = async (
     const entity = guaranteeNonNullable(
       (
         await client.entities(
-          new LegendEntitiesRequest([TextDocumentIdentifier.create(entityUri)]),
+          new LegendEntitiesRequest(
+            [TextDocumentIdentifier.create(entityUri)],
+            [entityId],
+          ),
         )
-      ).filter((_entity) => _entity.path === entityId)[0],
+      )[0],
       `No entity found with ID ${entityId} at ${entityUri}`,
     );
     if (

--- a/src/utils/Const.ts
+++ b/src/utils/Const.ts
@@ -82,7 +82,6 @@ export const GET_SUBTYPE_INFO_REQUEST_ID = 'legend/getSubtypeInfo';
 
 // Event Types
 export const GET_PROJECT_ENTITIES = 'getProjectEntities';
-export const GET_ENTITY_TEXT_LOCATION = 'getEntityTextLocation';
 export const DIAGRAM_DROP_CLASS_ERROR = 'diagramDropClassError';
 export const WRITE_ENTITY = 'writeEntity';
 export const QUERY_BUILDER_CONFIG_ERROR = 'queryBuilderConfigError';
@@ -90,7 +89,6 @@ export const EXPORT_DATA_COMMAND_ID = 'legend.query.exportData';
 
 // Response events
 export const GET_PROJECT_ENTITIES_RESPONSE = `${GET_PROJECT_ENTITIES}/response`;
-export const GET_ENTITY_TEXT_LOCATION_RESPONSE = `${GET_ENTITY_TEXT_LOCATION}/response`;
 export const GET_CURRENT_USER_ID_RESPONSE = `${GET_CURRENT_USER_ID_REQUEST_ID}/response`;
 export const GET_CLASSIFIER_PATH_MAP_RESPONSE = `${GET_CLASSIFIER_PATH_MAP_REQUEST_ID}/response`;
 export const GET_SUBTYPE_INFO_RESPONSE = `${GET_SUBTYPE_INFO_REQUEST_ID}/response`;

--- a/src/utils/Const.ts
+++ b/src/utils/Const.ts
@@ -82,6 +82,7 @@ export const GET_SUBTYPE_INFO_REQUEST_ID = 'legend/getSubtypeInfo';
 
 // Event Types
 export const GET_PROJECT_ENTITIES = 'getProjectEntities';
+export const GET_ENTITY_TEXT_LOCATION = 'getEntityTextLocation';
 export const DIAGRAM_DROP_CLASS_ERROR = 'diagramDropClassError';
 export const WRITE_ENTITY = 'writeEntity';
 export const QUERY_BUILDER_CONFIG_ERROR = 'queryBuilderConfigError';
@@ -89,6 +90,7 @@ export const EXPORT_DATA_COMMAND_ID = 'legend.query.exportData';
 
 // Response events
 export const GET_PROJECT_ENTITIES_RESPONSE = `${GET_PROJECT_ENTITIES}/response`;
+export const GET_ENTITY_TEXT_LOCATION_RESPONSE = `${GET_ENTITY_TEXT_LOCATION}/response`;
 export const GET_CURRENT_USER_ID_RESPONSE = `${GET_CURRENT_USER_ID_REQUEST_ID}/response`;
 export const GET_CLASSIFIER_PATH_MAP_RESPONSE = `${GET_CLASSIFIER_PATH_MAP_REQUEST_ID}/response`;
 export const GET_SUBTYPE_INFO_RESPONSE = `${GET_SUBTYPE_INFO_REQUEST_ID}/response`;

--- a/src/webviews/utils.ts
+++ b/src/webviews/utils.ts
@@ -41,6 +41,8 @@ import {
   GET_CLASSIFIER_PATH_MAP_RESPONSE,
   GET_CURRENT_USER_ID_REQUEST_ID,
   GET_CURRENT_USER_ID_RESPONSE,
+  GET_ENTITY_TEXT_LOCATION,
+  GET_ENTITY_TEXT_LOCATION_RESPONSE,
   GET_LAMBDA_RETURN_TYPE_COMMAND_ID,
   GET_LAMBDA_RETURN_TYPE_RESPONSE,
   GET_PROJECT_ENTITIES,
@@ -392,6 +394,30 @@ export const handleQueryBuilderWebviewMessage = async (
         command: GET_PROJECT_ENTITIES_RESPONSE,
         result: entities,
         updatedEntityId: message.updatedEntityId,
+      });
+      return true;
+    }
+    case GET_ENTITY_TEXT_LOCATION: {
+      const entityLocation = guaranteeNonNullable(
+        legendConceptTree.getTreeItemById(message.msg.entityId)?.location,
+        `Can't find entity with ID '${message.msg.entityId}'`,
+      );
+      const entityTextLocation = TextLocation.serialization.fromJson({
+        documentId: entityLocation.uri.toString(),
+        textInterval: {
+          start: {
+            line: entityLocation.range.start.line,
+            column: entityLocation.range.start.character,
+          },
+          end: {
+            line: entityLocation.range.end.line,
+            column: entityLocation.range.end.character,
+          },
+        },
+      });
+      webview.postMessage({
+        command: GET_ENTITY_TEXT_LOCATION_RESPONSE,
+        result: entityTextLocation,
       });
       return true;
     }

--- a/src/webviews/utils.ts
+++ b/src/webviews/utils.ts
@@ -398,6 +398,7 @@ export const handleQueryBuilderWebviewMessage = async (
       return true;
     }
     case GET_ENTITY_TEXT_LOCATION: {
+      await legendConceptTree.refresh();
       const entityLocation = guaranteeNonNullable(
         legendConceptTree.getTreeItemById(message.msg.entityId)?.location,
         `Can't find entity with ID '${message.msg.entityId}'`,

--- a/src/webviews/utils.ts
+++ b/src/webviews/utils.ts
@@ -41,8 +41,6 @@ import {
   GET_CLASSIFIER_PATH_MAP_RESPONSE,
   GET_CURRENT_USER_ID_REQUEST_ID,
   GET_CURRENT_USER_ID_RESPONSE,
-  GET_ENTITY_TEXT_LOCATION,
-  GET_ENTITY_TEXT_LOCATION_RESPONSE,
   GET_LAMBDA_RETURN_TYPE_COMMAND_ID,
   GET_LAMBDA_RETURN_TYPE_RESPONSE,
   GET_PROJECT_ENTITIES,
@@ -385,40 +383,16 @@ export const handleQueryBuilderWebviewMessage = async (
     case GET_PROJECT_ENTITIES: {
       const entities = await client.entities(
         new LegendEntitiesRequest(
-          message.msg?.entityTextLocations.map((textLocation: TextLocation) =>
+          message.msg?.entityTextLocations?.map((textLocation: TextLocation) =>
             TextDocumentIdentifier.create(textLocation.documentId),
           ) ?? [],
+          message.msg?.entityPaths ?? [],
         ),
       );
       webview.postMessage({
         command: GET_PROJECT_ENTITIES_RESPONSE,
         result: entities,
         updatedEntityId: message.updatedEntityId,
-      });
-      return true;
-    }
-    case GET_ENTITY_TEXT_LOCATION: {
-      await legendConceptTree.refresh();
-      const entityLocation = guaranteeNonNullable(
-        legendConceptTree.getTreeItemById(message.msg.entityId)?.location,
-        `Can't find entity with ID '${message.msg.entityId}'`,
-      );
-      const entityTextLocation = TextLocation.serialization.fromJson({
-        documentId: entityLocation.uri.toString(),
-        textInterval: {
-          start: {
-            line: entityLocation.range.start.line,
-            column: entityLocation.range.start.character,
-          },
-          end: {
-            line: entityLocation.range.end.line,
-            column: entityLocation.range.end.character,
-          },
-        },
-      });
-      webview.postMessage({
-        command: GET_ENTITY_TEXT_LOCATION_RESPONSE,
-        result: entityTextLocation,
       });
       return true;
     }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

Building on the work of https://github.com/finos/legend-engine-ide-client-vscode/pull/125, in order to further optimize setting up the query builder graph, this PR reduces the number of entities that are fetched to build the minimal graph.

Previously, we fetched all the entities from the LSP and then found the entity for the service/function we were trying to open in order to get its mapping. This PR optimizes performance by using the legend concept tree to get the text location of the service/function we are trying to open so that we can fetch only the entity we need instead of fetching all entities and then finding the one we need.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
Service query builder still works:
![Service](https://github.com/user-attachments/assets/99397283-2e34-40eb-b21c-95817dba4549)

Function query builder still works:
![Function](https://github.com/user-attachments/assets/7a679745-174b-45bc-b64d-a17afa9afeb1)