### PR TITLE
Pass `enableDataCube` flag when executing purebook cell

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,11 @@
           "type": "string",
           "default": "vX_X_X",
           "description": "Defines the protocol version to use"
+        },
+        "legend.purebook.enableDatacube": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show purebook execution relational results in Datacube"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -227,10 +227,10 @@
           "default": "vX_X_X",
           "description": "Defines the protocol version to use"
         },
-        "legend.purebook.enableDatacube": {
+        "legend.purebook.enableDataCube": {
           "type": "boolean",
           "default": true,
-          "description": "Show purebook execution relational results in Datacube"
+          "description": "Show purebook execution relational results in DataCube"
         }
       }
     },

--- a/src/purebook/PurebookController.ts
+++ b/src/purebook/PurebookController.ts
@@ -15,13 +15,14 @@
  */
 
 import {
-  commands,
   type NotebookCell,
+  type NotebookController,
   type NotebookDocument,
+  commands,
   NotebookCellOutput,
   NotebookCellOutputItem,
-  type NotebookController,
   notebooks,
+  workspace,
 } from 'vscode';
 import { LEGEND_COMMAND_V2, LEGEND_LANGUAGE_ID } from '../utils/Const';
 import { LegendExecutionResult } from '../results/LegendExecutionResult';
@@ -81,6 +82,10 @@ export class PurebookController {
       execution.end(undefined, Date.now());
     });
 
+    const enableDatacube = workspace
+      .getConfiguration('legend')
+      .get('purebook.enableDatacube', true);
+
     return commands
       .executeCommand(
         LEGEND_COMMAND_V2,
@@ -89,7 +94,9 @@ export class PurebookController {
         0,
         'notebook_cell',
         'executeCell',
-        {},
+        {
+          enableDatacube,
+        },
         {},
       )
       .then(

--- a/src/purebook/PurebookController.ts
+++ b/src/purebook/PurebookController.ts
@@ -82,9 +82,9 @@ export class PurebookController {
       execution.end(undefined, Date.now());
     });
 
-    const enableDatacube = workspace
+    const enableDataCube = workspace
       .getConfiguration('legend')
-      .get('purebook.enableDatacube', true);
+      .get('purebook.enableDataCube', true);
 
     return commands
       .executeCommand(
@@ -95,7 +95,7 @@ export class PurebookController {
         'notebook_cell',
         'executeCell',
         {
-          enableDatacube,
+          enableDataCube,
         },
         {},
       )


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

Improvement

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

This PR passes an `enableDataCube` flag to the LSP when executing a purebook cell, since the LSP will now use this flag to determine if it should execute a plan and return a plaintext result of the query or just return the lambda and let the client render a DataCube instance that executes the query.

The `enableDataCube` flag can be set by the user in the extension's settings.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->

Yes

Toggling flag:
![ToggleFlag](https://github.com/user-attachments/assets/5889c9b3-b7cb-4148-85bd-f500498e02df)