### PR TITLE
datacube: add config flags for query publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,17 @@
         "legend.agGridLicense": {
           "type": "string",
           "default": "",
-          "description": "Set the AgGrid License to enable enterprise features.  Without a licence, only community features are available"
+          "description": "Set the AgGrid License to enable enterprise features. Without a licence, only community features are available"
+        },
+        "legend.dataCube.queryServerBaseUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Set the DataCube query server base url to enable publishing queries."
+        },
+        "legend.dataCube.hostedApplicationBaseUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Set the hosted DataCube web application to enable viewing published queries."
         },
         "legend.extensions.dependencies.pom": {
           "type": "string",
@@ -187,7 +197,7 @@
         "legend.engine.server.remoteExecution": {
           "type": "boolean",
           "default": "true",
-          "description": "Defines if executions should happen locally or remotely.  Only used if server url is provided."
+          "description": "Defines if executions should happen locally or remotely. Only used if server url is provided."
         },
         "legend.sdlc.server.url": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -745,6 +745,12 @@ export function createReplTerminal(context: ExtensionContext): void {
     coderVSCodeProxyURLTemplate
       ? `-Dlegend.repl.dataCube.urlTemplate=${coderVSCodeProxyURLTemplate}`
       : undefined,
+    `-Dlegend.repl.dataCube.queryServerBaseUrl=${workspace
+      .getConfiguration('legend')
+      .get('dataCube.queryServerBaseUrl', '')}`,
+    `-Dlegend.repl.dataCube.hostedApplicationBaseUrl=${workspace
+      .getConfiguration('legend')
+      .get('dataCube.hostedApplicationBaseUrl', '')}`,
     `-Dlegend.repl.dataCube.gridLicenseKey=${workspace
       .getConfiguration('legend')
       .get('agGridLicense', '')}`,


### PR DESCRIPTION
This is follow-up work to enable query publishing in the REPL 
https://github.com/finos/legend-engine/pull/3298
https://github.com/finos/legend-studio/pull/3763