### PR TITLE
Download file on server when user exports data

### DIFF
--- a/packages/extension/src/LegendLanguageClient.ts
+++ b/packages/extension/src/LegendLanguageClient.ts
@@ -262,7 +262,11 @@ export class LegendLanguageClient extends LanguageClient {
     });
     if (!uri) {
       window.showErrorMessage('File save cancelled');
-      return undefined;
+      return LegendExecutionResult.serialization.fromJson({
+        ids: [],
+        type: LegendExecutionResultType.FAILURE,
+        message: 'File save cancelled',
+      });
     }
 
     const filePath = uri.path;

--- a/packages/extension/src/LegendLanguageClient.ts
+++ b/packages/extension/src/LegendLanguageClient.ts
@@ -22,7 +22,6 @@ import {
   ENTITIES_REQUEST_ID,
   EXECUTE_QUERY_COMMAND_ID,
   EXECUTE_TESTS_REQUEST_ID,
-  EXPORT_DATA_COMMAND_ID,
   GENERATE_EXECUTION_PLAN_COMMAND_ID,
   GET_CLASSIFIER_PATH_MAP_REQUEST_ID,
   GET_LAMBDA_RETURN_TYPE_COMMAND_ID,
@@ -264,21 +263,21 @@ export class LegendLanguageClient extends LanguageClient {
       });
     }
 
-    const filePath = uri.path;
+    const exportFilePath = uri.path;
     const executableArgs = {
       lambda: JSON.stringify(lambda),
       mapping,
       runtime: JSON.stringify(runtime),
       context: JSON.stringify(context),
       serializationFormat,
-      filePath,
+      exportFilePath,
     };
     const response = (
       entityDetails instanceof TextLocation
         ? await commands.executeCommand(
             LEGEND_COMMAND,
             entityDetails,
-            EXPORT_DATA_COMMAND_ID,
+            EXECUTE_QUERY_COMMAND_ID,
             executableArgs,
             parameterValues,
           )
@@ -287,7 +286,7 @@ export class LegendLanguageClient extends LanguageClient {
             entityDetails.documentUri,
             entityDetails.sectionIndex,
             entityDetails.entityId,
-            EXPORT_DATA_COMMAND_ID,
+            EXECUTE_QUERY_COMMAND_ID,
             executableArgs,
             parameterValues,
           )

--- a/packages/extension/src/LegendLanguageClient.ts
+++ b/packages/extension/src/LegendLanguageClient.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  commands,
-  Uri,
-  window,
-  type CancellationToken,
-} from 'vscode';
+import { commands, Uri, window, type CancellationToken } from 'vscode';
 import type { FunctionTDSRequest } from './model/FunctionTDSRequest';
 import {
   ANALYZE_MAPPING_MODEL_COVERAGE_COMMAND_ID,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

Improvement

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

This PR moves the logic for downloading exported data to the server so that the server doesn't need to send a potentially large query response back to the client for downloading. Instead, the client just sends the desired file path to the server, and the server handles downloading the data.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->

Yes

Export to CSV:
![ExportData](https://github.com/user-attachments/assets/bb83a5a3-dac1-4ff4-b2ad-a84f12b0d902)