### PR TITLE
Mark react as external in rollup config

### DIFF
--- a/packages/client/rollup.config.js
+++ b/packages/client/rollup.config.js
@@ -28,7 +28,7 @@ const extensions = ['.js', '.ts', '.jsx', '.tsx'];
 
 export default {
   input: 'src/index.ts',
-  external: ['@jest/globals', 'react-dom/server'],
+  external: ['@jest/globals', 'react-dom/server', 'react', 'react-dom'],
   output: [
     {
       file: 'lib/bundles/bundle.cjs.js',

--- a/packages/client/rollup.config.js
+++ b/packages/client/rollup.config.js
@@ -28,7 +28,14 @@ const extensions = ['.js', '.ts', '.jsx', '.tsx'];
 
 export default {
   input: 'src/index.ts',
-  external: ['@jest/globals', 'react-dom/server', 'react', 'react-dom'],
+  external: [
+    '@jest/globals',
+    'react-dom/server',
+    'react',
+    'react-dom',
+    '@finos/legend-engine-ide-client-vscode-shared',
+    '@finos/legend-vscode-extension-dependencies',
+  ],
   output: [
     {
       file: 'lib/bundles/bundle.cjs.js',

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -353,9 +353,10 @@
   "scripts": {
     "test": "yarn compile && yarn node ./lib/__tests__/runTest.js",
     "compile": "tsc -b",
-    "dev:webpack": "webpack --mode development --watch",
-    "webpack": "webpack --mode development",
-    "webpack:package": "webpack --mode production --devtool hidden-source-map",
+    "dev:webpack": "yarn clean && webpack --mode development --watch",
+    "webpack": "yarn clean && webpack --mode development",
+    "webpack:package": "yarn clean && webpack --mode production --devtool hidden-source-map",
+    "clean": "rm -rf \"dist\"",
     "check:copyright": "license-check-and-add check -f ../../license-check-and-add-config.json",
     "check:format": "prettier --list-different \"(src|scripts|docs)/**/*.{md,json,mjs,cjs,js,ts,tsx,html,scss,css}\"",
     "check:ci": "yarn check:format && yarn check:copyright",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -68,9 +68,5 @@
     "typescript": "5.7.2",
     "util": "0.12.5",
     "yo": "4.3.1"
-  },
-  "overrides": {
-    "react": "19.0.0",
-    "react-dom": "19.0.0"
   }
 }

--- a/packages/shared/rollup.config.js
+++ b/packages/shared/rollup.config.js
@@ -28,7 +28,7 @@ const extensions = ['.js', '.ts', '.jsx', '.tsx'];
 
 export default {
   input: 'src/index.ts',
-  external: ['@jest/globals', 'react-dom/server'],
+  external: ['@jest/globals', 'react-dom/server', 'react', 'react-dom'],
   output: [
     {
       file: 'lib/bundles/bundle.cjs.js',

--- a/packages/shared/rollup.config.js
+++ b/packages/shared/rollup.config.js
@@ -33,7 +33,6 @@ export default {
     'react-dom/server',
     'react',
     'react-dom',
-    '@finos/legend-vscode-extension-dependencies',
     '@types/vscode',
   ],
   output: [

--- a/packages/shared/rollup.config.js
+++ b/packages/shared/rollup.config.js
@@ -28,7 +28,14 @@ const extensions = ['.js', '.ts', '.jsx', '.tsx'];
 
 export default {
   input: 'src/index.ts',
-  external: ['@jest/globals', 'react-dom/server', 'react', 'react-dom'],
+  external: [
+    '@jest/globals',
+    'react-dom/server',
+    'react',
+    'react-dom',
+    '@finos/legend-vscode-extension-dependencies',
+    '@types/vscode',
+  ],
   output: [
     {
       file: 'lib/bundles/bundle.cjs.js',


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

Bug Fix

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

We need to mark react as external in the client package rollup config so that when components from the package are used, the end user doesn't end up with 2 copies of react running, which will cause react hooks to throw an error.

We also mark `@finos/legend-engine-ide-client-vscode-shared` and `@finos/legend-vscode-extension-dependencies` as external in the client's rollup config since those packages should be provided by whatever other code uses those libraries.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->

No