### PR TITLE
Set localResourceRoots in webview options to allow using local forms file

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -298,9 +298,11 @@ const showDiagramWebView = async (
           )
             ? [
                 Uri.file(
-                  workspace
-                    .getConfiguration('legend')
-                    .get('studio.forms.file', ''),
+                  path.dirname(
+                    workspace
+                      .getConfiguration('legend')
+                      .get('studio.forms.file', ''),
+                  ),
                 ),
               ]
             : []),
@@ -382,9 +384,11 @@ const showQueryBuilderWebView = async (
             )
               ? [
                   Uri.file(
-                    workspace
-                      .getConfiguration('legend')
-                      .get('studio.forms.file', ''),
+                    path.dirname(
+                      workspace
+                        .getConfiguration('legend')
+                        .get('studio.forms.file', ''),
+                    ),
                   ),
                 ]
               : []),

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -101,6 +101,7 @@ import { V1_getFunctionNameWithoutSignature } from './utils/V1_ProtocolUtils';
 import { type LegendEntity } from './model/LegendEntity';
 import { renderQueryBuilderWebView } from './webviews/QueryBuilderWebView';
 import { LegendCodelensProvider } from './LegendCodelensProvider';
+import { isLocalFilePath } from './webviews/utils';
 
 let client: LegendLanguageClient;
 const openedWebViews: Record<string, WebviewPanel> = {};
@@ -290,6 +291,20 @@ const showDiagramWebView = async (
       {
         enableScripts: true,
         retainContextWhenHidden: true,
+        localResourceRoots: [
+          context.extensionUri,
+          ...(isLocalFilePath(
+            workspace.getConfiguration('legend').get('studio.forms.file', ''),
+          )
+            ? [
+                Uri.file(
+                  workspace
+                    .getConfiguration('legend')
+                    .get('studio.forms.file', ''),
+                ),
+              ]
+            : []),
+        ],
       },
     );
     diagramRendererWebView.onDidDispose(() => {
@@ -360,6 +375,20 @@ const showQueryBuilderWebView = async (
         {
           enableScripts: true,
           retainContextWhenHidden: true,
+          localResourceRoots: [
+            context.extensionUri,
+            ...(isLocalFilePath(
+              workspace.getConfiguration('legend').get('studio.forms.file', ''),
+            )
+              ? [
+                  Uri.file(
+                    workspace
+                      .getConfiguration('legend')
+                      .get('studio.forms.file', ''),
+                  ),
+                ]
+              : []),
+          ],
         },
       );
       openedWebViews[normalizedEntityId] = queryBuilderWebView;

--- a/packages/extension/src/purebook/purebook.ts
+++ b/packages/extension/src/purebook/purebook.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { dirname } from 'path';
 import {
   type CancellationToken,
   type ExtensionContext,
@@ -44,6 +45,7 @@ import {
   type PlainObject,
   type V1_RawLambda,
 } from '@finos/legend-vscode-extension-dependencies';
+import { isLocalFilePath } from '../webviews/utils';
 
 interface RawNotebookCell {
   source: string[];
@@ -117,6 +119,22 @@ const showDatacubeWebView = async (
       {
         enableScripts: true,
         retainContextWhenHidden: true,
+        localResourceRoots: [
+          context.extensionUri,
+          ...(isLocalFilePath(
+            workspace.getConfiguration('legend').get('studio.forms.file', ''),
+          )
+            ? [
+                Uri.file(
+                  dirname(
+                    workspace
+                      .getConfiguration('legend')
+                      .get('studio.forms.file', ''),
+                  ),
+                ),
+              ]
+            : []),
+        ],
       },
     );
     openedWebViews[cellUri] = dataCubeWebView;

--- a/packages/extension/src/webviews/utils.ts
+++ b/packages/extension/src/webviews/utils.ts
@@ -27,6 +27,7 @@ import {
   type TextLocation,
   GET_PROJECT_ENTITIES,
   GET_PROJECT_ENTITIES_RESPONSE,
+  isEmpty,
   QUERY_BUILDER_CONFIG_ERROR,
   WRITE_ENTITY,
 } from '@finos/legend-engine-ide-client-vscode-shared';
@@ -38,6 +39,7 @@ import { type LegendConceptTreeProvider } from '../conceptTree';
 import { TextDocumentIdentifier } from 'vscode-languageclient';
 
 export const isLocalFilePath = (filePath: string): boolean =>
+  !isEmpty(filePath) &&
   new URL(filePath, workspace.workspaceFolders?.[0]?.uri.toString())
     .protocol === 'file:';
 

--- a/packages/extension/src/webviews/utils.ts
+++ b/packages/extension/src/webviews/utils.ts
@@ -37,6 +37,10 @@ import {
 import { type LegendConceptTreeProvider } from '../conceptTree';
 import { TextDocumentIdentifier } from 'vscode-languageclient';
 
+export const isLocalFilePath = (filePath: string): boolean =>
+  new URL(filePath, workspace.workspaceFolders?.[0]?.uri.toString())
+    .protocol === 'file:';
+
 export const getWebviewHtml = (
   webview: Webview,
   webviewType: string,
@@ -44,7 +48,9 @@ export const getWebviewHtml = (
   renderFilePath: string,
   dataInputParams: PlainObject,
 ): string => {
-  // Get script to use for web view
+  // Get script to use for webview.
+  // If renderFilePath isn't provided, we use the default WebViewRoot.js file
+  // packaged with the extension.
   let webviewRootScript;
   if (renderFilePath.length === 0) {
     const webviewRootScriptPath = Uri.file(
@@ -53,10 +59,7 @@ export const getWebviewHtml = (
     webviewRootScript = webview.asWebviewUri(webviewRootScriptPath);
   } else {
     // If the provided renderFilePath is a local file, we need to convert it to a webview URI
-    if (
-      new URL(renderFilePath, workspace.workspaceFolders?.[0]?.uri.toString())
-        .protocol === 'file:'
-    ) {
+    if (isLocalFilePath(renderFilePath)) {
       webviewRootScript = webview.asWebviewUri(Uri.file(renderFilePath));
     } else {
       webviewRootScript = renderFilePath;

--- a/packages/shared/src/utils/AssertionUtils.ts
+++ b/packages/shared/src/utils/AssertionUtils.ts
@@ -69,3 +69,6 @@ export const isObject = (val: unknown): val is object =>
 
 export const isPlainObject = (val: unknown): val is PlainObject =>
   isObject(val) && val.constructor.name === 'Object';
+
+export const isEmpty = (val: string): boolean =>
+  val === undefined || val === null || val.trim() === '';


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

Bug Fix

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

This PR adds the studio forms file directory to the webview options localResourceRoots property so that the webview has permission to load a script from the user's local file system. Without this option, VSCode doesn't allow a webview to load something from the user's local file system for security reasons.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->

No