### PR TITLE
Add MAINTAINERS.md file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,22 +4,22 @@ This file lists the maintainers of this repository.
 
 ## Current maintainers
 
-| GitHub Username | Name | Organization | Email |
-|----------------|------|--------------|-------|
-| @AFine-gs | *please add name* | *please add organization* | *please add email* |
+| GitHub Username | Name | Organization | Email (optional) |
+|----------------|------|--------------|------------------|
+| @AFine-gs | *please add name* | *please add organization* |  |
 | @MauricioUyaguari | Mauricio Uyaguari | *please add organization* | lmauricio12@gmail.com |
-| @Yasirmod17 | Mohammed Ibrahim | *please add organization* | *please add email* |
-| @agitana | Aitana Myohl | Goldman Sachs | *please add email* |
-| @aormerod-gs | Andrew Ormerod | *please add organization* | *please add email* |
-| @aziemchawdhary-gs | Aziem Chawdhary | *please add organization* | *please add email* |
-| @davidharte-gs | *please add name* | *please add organization* | *please add email* |
-| @gs-gunjan | *please add name* | *please add organization* | *please add email* |
-| @gs-jp1 | *please add name* | *please add organization* | *please add email* |
+| @Yasirmod17 | Mohammed Ibrahim | *please add organization* |  |
+| @agitana | Aitana Myohl | Goldman Sachs |  |
+| @aormerod-gs | Andrew Ormerod | *please add organization* |  |
+| @aziemchawdhary-gs | Aziem Chawdhary | *please add organization* |  |
+| @davidharte-gs | *please add name* | *please add organization* |  |
+| @gs-gunjan | *please add name* | *please add organization* |  |
+| @gs-jp1 | *please add name* | *please add organization* |  |
 | @gs-rpant1729 | *please add name* | *please add organization* | rohit.r.pant@gs.com |
-| @ivan-kyosev-gs | *please add name* | *please add organization* | *please add email* |
-| @kevin-m-knight-gs | Kevin Knight | Goldman Sachs | *please add email* |
-| @mimi-tam | *please add name* | *please add organization* | *please add email* |
-| @rafaelbey | Rafael Bey-Hernandez | Goldman Sachs | *please add email* |
+| @ivan-kyosev-gs | *please add name* | *please add organization* |  |
+| @kevin-m-knight-gs | Kevin Knight | Goldman Sachs |  |
+| @mimi-tam | *please add name* | *please add organization* |  |
+| @rafaelbey | Rafael Bey-Hernandez | Goldman Sachs |  |
 
 For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,34 @@
+# Maintainers
+
+This file lists the maintainers of this repository.
+
+## Current maintainers
+
+| GitHub Username | Name | Organization | Email |
+|----------------|------|--------------|-------|
+| @AFine-gs | *please add name* | *please add organization* | *please add email* |
+| @MauricioUyaguari | Mauricio Uyaguari | *please add organization* | lmauricio12@gmail.com |
+| @Yasirmod17 | Mohammed Ibrahim | *please add organization* | *please add email* |
+| @agitana | Aitana Myohl | Goldman Sachs | *please add email* |
+| @aormerod-gs | Andrew Ormerod | *please add organization* | *please add email* |
+| @aziemchawdhary-gs | Aziem Chawdhary | *please add organization* | *please add email* |
+| @davidharte-gs | *please add name* | *please add organization* | *please add email* |
+| @gs-gunjan | *please add name* | *please add organization* | *please add email* |
+| @gs-jp1 | *please add name* | *please add organization* | *please add email* |
+| @gs-rpant1729 | *please add name* | *please add organization* | rohit.r.pant@gs.com |
+| @ivan-kyosev-gs | *please add name* | *please add organization* | *please add email* |
+| @kevin-m-knight-gs | Kevin Knight | Goldman Sachs | *please add email* |
+| @mimi-tam | *please add name* | *please add organization* | *please add email* |
+| @rafaelbey | Rafael Bey-Hernandez | Goldman Sachs | *please add email* |
+
+For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
+
+## Updating this file
+
+All changes to the maintainer list are managed openly:
+
+- **Submit a Pull Request** to this file for any addition, removal, or update.
+- **If your project's governance requires a vote**, document or link to the vote outcome in the PR description or comments.
+- This process creates a public audit trail of project leadership over time.
+
+Please email **help@finos.org** whenever this file is updated with a change to maintainership.


### PR DESCRIPTION
This PR adds a `MAINTAINERS.md` file to the root of this repository as part of a FINOS-wide effort to standardize maintainer signaling across all FINOS projects. An announcement was sent to **community@finos.org** with the full context, see [announcement email here](https://groups.google.com/u/1/a/finos.org/g/community/c/QkcKUec9O4w).

## How this list was generated

The maintainers were determined from this repository's GitHub settings:
- Users with `maintain` or `admin` role on the repository
- Members of teams with `maintain` or `admin` permission


Each entry includes the GitHub username, name, and organization pulled from the user's public GitHub profile. Where name or organization is missing, a `*please add ...*` placeholder marks where to fill in the value. Email is optional: it is included when the user has a public GitHub email, otherwise the cell is left blank.

**If no maintainers were detected automatically** (e.g. your repo has no users or teams with `maintain`/`admin` role), the table is intentionally empty. Please populate it manually on this branch before merging and email help@finos.org.

## What we need from this project's maintainers

1. **Review** the list for completeness and accuracy.
2. **Update** any incorrect or placeholder values (names, organization) directly on this branch. Email is optional.
3. **Add** anyone missing, edit the file in this PR if a maintainer was not automatically detected.
4. **Merge** when the list is accurate.

If your project does not need a `MAINTAINERS.md` for any reason, just close this PR and let us know at help@finos.org.

If this repository should instead be archived (e.g. it is no longer actively maintained or has been superseded), please email help@finos.org instead so we can coordinate the archival with you.

If you already have a MAINTAINERS.md file, you can close this PR. Please update your existing file if needed and place it in the root of the repository.

## Multi-repo projects: share one MAINTAINERS.md

If this repository is part of a project with multiple repositories that share (and will continue to share) the same maintainers, you don't need a separate list per repo. Pick one repository (typically the project's main/umbrella repo) to host the canonical `MAINTAINERS.md`, and on every other repo replace the table in this PR with a short note pointing readers there, for example:

> The maintainers of this repository are listed in the main project repository. See list [here](https://github.com/finos/PROJECT-MAIN-REPO/blob/main/MAINTAINERS.md).

That way maintainer changes only need to be made in one place going forward.

## Going forward: keeping the list current

To keep maintainer changes transparent and aligned with open governance:
- **Any change to the maintainer list must be made via a PR to this file.**
- If your project's governance requires a vote, **document or link to the vote outcome in the PR description or comments.**
- This gives the community a public audit trail of project leadership over time.

If you have any questions about the format or process, please email **help@finos.org**.

Thank you for your review!